### PR TITLE
fix(ci): repair release-please version substitution; target 0.2.0

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -13,8 +13,7 @@
       "extra-files": [
         {
           "type": "generic",
-          "path": "segnomms/__init__.py",
-          "glob": "__version__ = \"{version}\""
+          "path": "segnomms/__init__.py"
         }
       ]
     }

--- a/segnomms/__init__.py
+++ b/segnomms/__init__.py
@@ -161,7 +161,7 @@ except ImportError:
     _intents_available = False
 
 # Version information
-__version__ = "0.1.0b4"
+__version__ = "0.1.0b4"  # x-release-please-version
 __author__ = "SYSTMMS"
 
 # Export main functionality


### PR DESCRIPTION
## Summary

- Repair the broken `extra-files` rule in `.github/release-please-config.json`: the `glob` field isn't a real release-please option and was silently ignored, so `__version__` in `segnomms/__init__.py` was never rewritten during the v0.1.0 release (and both that tag and current `main` still say `0.1.0b4`).
- Add the standard `# x-release-please-version` annotation to `segnomms/__init__.py` so release-please's generic updater finds the version literal on the next release.
- Redirect release-please to cut **0.2.0** instead of the `1.0.0` it currently proposes in PR #2, since this will be the first public PyPI release of segnomms.

Context: segnomms is currently only published to a private GAR index. Downstream Chaquopy/Android consumer (`qrcodemms`) cannot authenticate to GAR and needs a public PyPI version to install. PyPI project name `segnomms` is currently unclaimed; a pending PyPI Trusted Publisher will be configured before merge so the publish workflow can authenticate via OIDC.

The `Release-As: 0.2.0` trailer in the commit body redirects release-please away from its current `1.0.0` calculation (driven by a `feat!:` "drop Python 3.9" since v0.1.0) — `1.0.0` is a stronger API-stability commitment than appropriate for a still-Beta-classifier plugin.

## Test plan

- [ ] Merge this PR
- [ ] Close PR #2 (`chore: release 1.0.0`) — release-please will reopen with `0.2.0`
- [ ] Pending PyPI Trusted Publisher registered on pypi.org (project=segnomms, owner=systmms, repo=segnomms, workflow=release-please.yml, environment=pypi)
- [ ] GitHub Environment `pypi` created on systmms/segnomms repo settings
- [ ] Verify the next release-please PR rewrites `__version__` to `0.2.0` in `segnomms/__init__.py` (this validates the fix)
- [ ] Local build + smoke install from that PR's branch before merging
- [ ] Merge the 0.2.0 release-please PR; `build-and-publish` job uploads to public PyPI via OIDC
- [ ] `pip install segnomms==0.2.0` in a clean venv resolves from PyPI with no auth