### PR TITLE
fix: align __version__ literal with release-please manifest

### DIFF
--- a/segnomms/__init__.py
+++ b/segnomms/__init__.py
@@ -161,7 +161,7 @@ except ImportError:
     _intents_available = False
 
 # Version information
-__version__ = "0.1.0b4"  # x-release-please-version
+__version__ = "0.1.0"  # x-release-please-version
 __author__ = "SYSTMMS"
 
 # Export main functionality


### PR DESCRIPTION
## Summary

After PR #44 merged, release-please's force-pushed PR #2 attempted to substitute the version literal `__version__ = "0.1.0b4"` to `0.2.0`, but produced `"0.2.0b4"` instead — leaving `b4` debris.

Root cause: the manifest declares the last released version as `0.1.0`, but the file held a stale `0.1.0b4` from before v0.1.0 was cut. Release-please's generic updater performs a substring replace of the manifest version on the annotated line; it found `0.1.0` inside `0.1.0b4` and replaced only that substring, leaving the `b4` suffix dangling.

Aligning the literal to `0.1.0` lets the substitution match the full version and produce a clean `0.2.0` on the next release-please run. This also future-proofs: the file's version and the manifest must always match exactly going forward, so PEP 440 prerelease suffixes won't cause this same debris on future releases.

## Test plan

- [ ] Merge this PR
- [ ] Verify release-please re-runs and force-pushes PR #2 with the corrected `__version__ = "0.2.0"` (no `b4` suffix)
- [ ] Smoke-test the rewritten PR #2 branch locally before merging it