### PR TITLE
fix(deps): move myst-parser from runtime to docs dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "segno>=1.5.2", # Tested compatibility: 1.5.2, 1.6.0, 1.6.6
     "pydantic>=2.7,<3", # For configuration validation and JSON schema with enum objects
     "typing-extensions>=4.8; python_version<'3.11'", # For modern typing features
-    "myst-parser>=0.18.0",
 ]
 
 # Development dependencies have been migrated to [dependency-groups]
@@ -289,6 +288,7 @@ dev = [
     "sphinx>=7.0.0",
     "sphinx-rtd-theme>=2.0.0",
     "sphinx-autodoc-typehints>=1.19.0",
+    "myst-parser>=0.18.0", # Sphinx Markdown extension, used in docs/source/conf.py
     # Visual testing helpers
     "pillow>=10.0.0",
     "numpy>=1.20.0",


### PR DESCRIPTION
## Summary

`myst-parser` is declared in `[project.dependencies]` but isn't imported anywhere in the `segnomms/` package — `grep -rE "import myst|from myst" segnomms/` returns zero hits. It's only used in `docs/source/conf.py:40` as a Sphinx extension for Markdown docstring rendering.

Declaring it as a runtime dependency means every `pip install segnomms` pulls in sphinx, docutils, markdown-it-py, mdit-py-plugins, and six `sphinxcontrib-*` packages — about a dozen transitive packages of pure docs-tooling that runtime code never touches. This matters especially for downstream consumers in size-sensitive contexts (e.g., qrcodemms's Chaquopy/Android build) where each transitive package adds APK weight.

Moving it to the `dev` dependency group (alongside the other Sphinx tools already there) keeps docs builds working via `uv sync` / `make setup` while shrinking the runtime install to just `segno`, `pydantic`, and `typing-extensions` (Python <3.11 only).

This needs to land before 0.2.0 publishes so the first public PyPI release ships with a clean runtime dep tree.

## Test plan

- [ ] CI green (no runtime imports of myst-parser exist anywhere)
- [ ] `make docs` still builds successfully (myst-parser available via dev group)
- [ ] After merge: release-please re-runs and force-pushes PR #2 with the cleaner pyproject.toml
- [ ] Smoke install of the new wheel pulls only `segno`, `pydantic`, `typing-extensions` (no sphinx/docutils/etc.)