### PR TITLE
fix(ci): repair release workflow + cut 0.2.1

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          uv pip install build twine
+          uv pip install --system build twine
 
       - name: Build package
         run: python -m build
@@ -145,7 +145,8 @@ jobs:
             -H "Authorization: Token $RTD_TOKEN" \
             -H "Content-Type: application/json" \
             -d '{"active": true, "hidden": false}' \
-            "https://readthedocs.org/api/v3/projects/$RTD_PROJECT/versions/$RTD_VERSION/"
+            "https://readthedocs.org/api/v3/projects/$RTD_PROJECT/versions/$RTD_VERSION/" \
+          || echo "::warning::RTD activate failed (project or version may not be set up yet); not blocking the release"
 
       - name: Trigger RTD build for release tag
         if: ${{ env.RTD_TOKEN != '' }}
@@ -153,7 +154,8 @@ jobs:
           echo "Triggering RTD build for tag \"$RTD_VERSION\""
           curl -fsSL -X POST \
             -H "Authorization: Token $RTD_TOKEN" \
-            "https://readthedocs.org/api/v3/projects/$RTD_PROJECT/versions/$RTD_VERSION/builds/"
+            "https://readthedocs.org/api/v3/projects/$RTD_PROJECT/versions/$RTD_VERSION/builds/" \
+          || echo "::warning::RTD build trigger for $RTD_VERSION failed; not blocking the release"
 
       - name: Trigger RTD build for latest
         if: ${{ env.RTD_TOKEN != '' }}
@@ -161,7 +163,8 @@ jobs:
           echo "Triggering Read the Docs build for project \"$RTD_PROJECT\" (version: latest)"
           curl -fsSL -X POST \
             -H "Authorization: Token $RTD_TOKEN" \
-            "https://readthedocs.org/api/v3/projects/$RTD_PROJECT/versions/latest/builds/"
+            "https://readthedocs.org/api/v3/projects/$RTD_PROJECT/versions/latest/builds/" \
+          || echo "::warning::RTD build trigger for latest failed; not blocking the release"
 
       - name: Trigger RTD build for stable (best-effort)
         if: ${{ env.RTD_TOKEN != '' }}


### PR DESCRIPTION
## Summary

When PR #2 merged, the `release-please.yml` workflow created the v0.2.0 git tag and GitHub Release as expected, then died at the publish step before anything reached PyPI. Failed run: https://github.com/systmms/segnomms/actions/runs/25973291077

Two distinct workflow issues surfaced:

1. **`uv pip install build twine` failed** — `astral-sh/setup-uv@v7` (bumped from v3 by recent dependabot) installs uv >=0.5, which requires either an active venv or `--system` for `uv pip install`. Adding `--system` restores the original intent without needing a venv setup step.

2. **RTD activate step exited non-zero on 404** — the `segnomms` project isn't set up on Read the Docs yet, so `curl -fsSL` against the activate endpoint fails. The RTD job runs in parallel with build-and-publish (doesn't block it) but a failing job marks the whole workflow as failed. Making the three blocking RTD curl steps lenient (log a workflow warning, don't fail the job) — matches the pre-existing pattern on the "stable (best-effort)" step.

## Why cut 0.2.1 instead of redoing 0.2.0

Once release-please cuts `v0.2.0`, it won't re-cut the same version. The `build-and-publish` job is gated on `needs.release-please.outputs.release_created`, so even after this workflow fix lands and re-triggers the release-please flow on main, the publish step would be skipped (release-please sees: nothing new since the last released version).

Redoing 0.2.0 would require destructive ops: deleting the GH release, resetting `.release-please-manifest.json`, and force-moving the v0.2.0 git tag. Cutting 0.2.1 with a `Release-As: 0.2.1` trailer (in this PR's commit) sidesteps all of that — the only cost is that the v0.2.0 GH release stays as a cosmetic-only entry with no PyPI artifact attached, and `qrcodemms` pins to `0.2.1` instead of `0.2.0`.

## Test plan

- [ ] Merge this PR
- [ ] Release-please opens a PR for `0.2.1` on its next run
- [ ] Locally smoke-test the regenerated release-please PR branch (already verified the wheel pipeline works for 0.2.0; only the workflow's `uv pip install` line changed)
- [ ] Merge the release-please 0.2.1 PR
- [ ] Watch the workflow: `build-and-publish` should reach `pypa/gh-action-pypi-publish` and succeed via OIDC
- [ ] RTD job now logs warnings instead of failing
- [ ] `pip install segnomms==0.2.1` in a fresh venv (no extra index, no auth) works
- [ ] `https://pypi.org/project/segnomms/0.2.1/` exists, owned by the systmms PyPI org