### PR TITLE
fix(ci): allow coverage comments on dependabot PRs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,6 +23,10 @@ on:
 env:
   PYTHON_VERSION: "3.11"
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   coverage-analysis:
     name: Coverage Analysis
@@ -186,12 +190,16 @@ jobs:
           ${diff > 5 ? '🎉 **Great!** Coverage improved significantly!' : ''}
           `;
 
-          await github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: body
-          });
+          try {
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
+          } catch (error) {
+            console.log('Could not post coverage diff comment:', error.message);
+          }
 
   coverage-quality-gate:
     name: Coverage Quality Gate


### PR DESCRIPTION
## Summary

All open dependabot PRs (#36, #37, #38, #39, #40, #41) currently fail CI on `Coverage Diff` and `Coverage Quality Gate` jobs. The failures are not related to the dependency bumps themselves — it's a workflow bug.

**Diagnosis** (failed run example: https://github.com/systmms/segnomms/actions/runs/24326253181):

```
RequestError [HttpError]: Resource not accessible by integration
##[error]Unhandled error: HttpError: Resource not accessible by integration
```

The `coverage-diff` job at `.github/workflows/coverage.yml:189` calls `github.rest.issues.createComment` to post a coverage diff comment back to the PR. This API requires `pull-requests: write` permission. But:

1. The workflow has no `permissions:` block, so `GITHUB_TOKEN` gets the repo default.
2. For **dependabot-triggered** workflow runs, GitHub issues a read-only `GITHUB_TOKEN` regardless of repo defaults — a security measure against malicious dependency PRs using comment APIs for exfiltration or coercion.
3. The createComment call rejects, the unhandled promise rejection fails the step, the job fails, and `Coverage Quality Gate` (which has `needs: [coverage-diff]` + `if: always()`) reports failure too.

The analogous comment call in the `coverage-analysis` job (line 92) survives because it's wrapped in try/catch; this one was not.

## Fix

1. **Add a workflow-level `permissions:` block** granting `pull-requests: write`. This is honored even on dependabot-triggered runs as long as the repo's workflow-permissions setting allows write scopes (`release-please.yml` already declares `pull-requests: write` and works, so this should be the case).

2. **Wrap the `coverage-diff` createComment in try/catch**, mirroring the pattern already in place in the `coverage-analysis` job. Belt-and-suspenders: even if the permission grant ever gets rolled back or the API changes, the workflow degrades gracefully.

## Test plan

- [ ] CI green on this PR (no dependabot trigger, so it should pass)
- [ ] Merge this PR
- [ ] Re-run CI on one of the failing dependabot PRs (e.g., #41)
- [ ] Expect: `Coverage Diff` step succeeds, coverage comment now appears on the dependabot PR
- [ ] All 6 open dependabot PRs become mergeable

## Notes

If after merge dependabot PR CI is still failing with the same error, check repo Settings → Actions → General → "Workflow permissions". If it's set to "Read repository contents and packages permissions", change it to "Read and write permissions" (or add explicit `pull-requests: write` at the workflow level, which we did).